### PR TITLE
removing redundant spaces in prog_list file if any

### DIFF
--- a/main.py
+++ b/main.py
@@ -250,7 +250,7 @@ else:
     
 session = WolframLanguageSession()
 with open(os.path.join(PATH, "program_list.txt"), "r") as f:
-    prognames = f.read().split("\n")
+    prognames = f.read().strip().split("\n")
 
 if smoke_test: 
     prognames = ["Geo0"]


### PR DESCRIPTION
sometimes main.py reads space characters and treats them as a program name in the list. just use stript() to avoid such cases.